### PR TITLE
Fix OSX/Linux builds

### DIFF
--- a/.ci_support/linux_64_python3.7.yaml
+++ b/.ci_support/linux_64_python3.7.yaml
@@ -17,7 +17,7 @@ docker_image:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '7'
+- '7.3'
 numpy:
 - '1.16'
 pin_run_as_build:

--- a/.ci_support/linux_64_python3.7.yaml
+++ b/.ci_support/linux_64_python3.7.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 fortran_compiler:

--- a/.ci_support/linux_64_python3.8.yaml
+++ b/.ci_support/linux_64_python3.8.yaml
@@ -17,7 +17,7 @@ docker_image:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '7'
+- '7.3'
 numpy:
 - '1.16'
 pin_run_as_build:

--- a/.ci_support/linux_64_python3.8.yaml
+++ b/.ci_support/linux_64_python3.8.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 fortran_compiler:

--- a/.ci_support/linux_64_python3.9.yaml
+++ b/.ci_support/linux_64_python3.9.yaml
@@ -17,7 +17,7 @@ docker_image:
 fortran_compiler:
 - gfortran
 fortran_compiler_version:
-- '7'
+- '7.3'
 numpy:
 - '1.16'
 pin_run_as_build:

--- a/.ci_support/linux_64_python3.9.yaml
+++ b/.ci_support/linux_64_python3.9.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '7'
+- '7.3'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '7'
+- '7.3'
 docker_image:
 - quay.io/condaforge/linux-anvil-comp7
 fortran_compiler:

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,3 +1,9 @@
+set -e -x
+
+if [ "$(uname)" = "Darwin" ]; then
+    CFLAGS+=" -Wno-error=deprecated-declarations "
+fi
+
 ./configure --enable-python --disable-perl --disable-java --disable-ruby \
 	    --disable-fortran2003 --disable-lua --prefix=$PREFIX
 make

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -9,7 +9,7 @@ c_compiler_version:    # [linux]
 cxx_compiler_version:  # [linux]
   - 7.3                # [linux]
 fortran_compiler_version:  # [unix]
-  - 7                      # [linux]
+  - 7.3                    # [linux]
   - 4                      # [osx and x86_64]
 numpy:
   - 1.16

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,9 +5,9 @@ channel_targets:
 cdt_name:
   - cos6
 c_compiler_version:    # [linux]
-  - 7                  # [linux]
+  - 7.3                # [linux]
 cxx_compiler_version:  # [linux]
-  - 7                  # [linux]
+  - 7.3                # [linux]
 fortran_compiler_version:  # [unix]
   - 7                      # [linux]
   - 4                      # [osx and x86_64]


### PR DESCRIPTION
#5 had a failing OSX/Python 3.8 build.
Linux builds fail on C/C++ 7.5, so downgrading them to 7.3.